### PR TITLE
Added a fix for Wikipedia (& other apps perhaps)...

### DIFF
--- a/app/src/main/java/fr/gouv/etalab/mastodon/activities/TootActivity.java
+++ b/app/src/main/java/fr/gouv/etalab/mastodon/activities/TootActivity.java
@@ -391,8 +391,8 @@ public class TootActivity extends AppCompatActivity implements OnRetrieveSearcAc
                     final String image = intent.getStringExtra("image");
                     String title = intent.getStringExtra("title");
                     String description = intent.getStringExtra("description");
-                    if( description != null ){
-                        if( title != null)
+                    if( description != null && description.length() > 0){
+                        if( title != null && title.length() > 0)
                             sharedContent = title + "\n\n" + description + "\n\n" + sharedContentIni;
                         else
                             sharedContent = description + "\n\n" + sharedContentIni;


### PR DESCRIPTION
Adds extra checks to make sure title & description have content before replacing the original sharedContent with either of them.

I noticed that when sharing from Wikipedia these values are both empty non-null Strings (""), which were then pasted into the toot rather than the original sharedContent contents. So you just ended up with the URL with no context in your shared-from-Wikipedia toot. It might fix other app sharing too, but I've only noticed this with Wikipedia.