### PR TITLE
Added a fix for a url that arrives sans 'http://'.

### DIFF
--- a/app/src/main/java/fr/gouv/etalab/mastodon/activities/TootActivity.java
+++ b/app/src/main/java/fr/gouv/etalab/mastodon/activities/TootActivity.java
@@ -392,6 +392,8 @@ public class TootActivity extends AppCompatActivity implements OnRetrieveSearcAc
                     String title = intent.getStringExtra("title");
                     String description = intent.getStringExtra("description");
                     if( description != null && description.length() > 0){
+                        if (sharedContentIni.startsWith("www."))
+                            sharedContentIni = "http://" + sharedContentIni;
                         if( title != null && title.length() > 0)
                             sharedContent = title + "\n\n" + description + "\n\n" + sharedContentIni;
                         else

--- a/app/src/main/java/fr/gouv/etalab/mastodon/asynctasks/RetrieveMetaDataAsyncTask.java
+++ b/app/src/main/java/fr/gouv/etalab/mastodon/asynctasks/RetrieveMetaDataAsyncTask.java
@@ -51,6 +51,10 @@ public class RetrieveMetaDataAsyncTask extends AsyncTask<Void, Void, Void> {
         String potentialUrl = "";
         try {
             Matcher matcher;
+
+            if (url.startsWith("www."))
+                url = "http://" + url;
+
             if (Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT)
                 matcher = Patterns.WEB_URL.matcher(url);
             else


### PR DESCRIPTION
See toot: https://mastodon.xyz/@PhotonQyv/99087475125987362 (Used BBC iPlayer app as example), versus: https://mastodon.xyz/@PhotonQyv/99087639007346080 after the additional fix of adding 'http://' into actual toot text.