### PR TITLE
TumblrFix: Added code to change an image URL to 'https://' rather than 'http://'…

### DIFF
--- a/app/src/main/java/fr/gouv/etalab/mastodon/activities/TootActivity.java
+++ b/app/src/main/java/fr/gouv/etalab/mastodon/activities/TootActivity.java
@@ -371,7 +371,9 @@ public class TootActivity extends AppCompatActivity implements OnRetrieveSearcAc
             receive_picture = new BroadcastReceiver() {
                 @Override
                 public void onReceive(Context context, Intent intent) {
-                    final String image = intent.getStringExtra("image");
+                    final String image = intent.getStringExtra("image").startsWith("http://") ?
+                            intent.getStringExtra("image").replace("http://", "https://") :
+                            intent.getStringExtra("image");
                     String title = intent.getStringExtra("title");
                     String description = intent.getStringExtra("description");
                     if( description != null && description.length() > 0){


### PR DESCRIPTION
… so that sharing from Tumblr works.

Note: Currently if you mention someone, and image URL has been fixed the end (last character)of the URL in toot gets removed in TootActivity.